### PR TITLE
Added: Feature - Scale -> Ticks -> beginAtZero

### DIFF
--- a/src/main/java/org/vaadin/addons/chartjs/options/scale/Ticks.java
+++ b/src/main/java/org/vaadin/addons/chartjs/options/scale/Ticks.java
@@ -16,6 +16,7 @@ public class Ticks<T> extends And<T> implements JsonBuilder {
   private static final long serialVersionUID = -4740687096401461147L;
 
   private Boolean autoSkip;
+  private Boolean beginAtZero;
   private Boolean display;
   private String fontColor;
   private String fontFamily;
@@ -40,6 +41,12 @@ public class Ticks<T> extends And<T> implements JsonBuilder {
   public Ticks<T> autoSkip(boolean autoSkip) {
     this.autoSkip = autoSkip;
     return this;
+  }
+
+  /** If true, scale starts at 0. */
+  public Ticks<T> beginAtZero(boolean beginAtZero) {
+      this.beginAtZero = beginAtZero;
+      return this;
   }
 
   /** If true, show the ticks. */
@@ -155,6 +162,7 @@ public class Ticks<T> extends And<T> implements JsonBuilder {
     JsonObject map = Json.createObject();
     JUtils.putNotNull(map, "display", display);
     JUtils.putNotNull(map, "autoSkip", autoSkip);
+    JUtils.putNotNull(map, "beginAtZero", beginAtZero);
     JUtils.putNotNull(map, "fontColor", fontColor);
     JUtils.putNotNull(map, "fontFamily", fontFamily);
     JUtils.putNotNull(map, "fontSize", fontSize);


### PR DESCRIPTION
This adds the possibility to begin the scale at zero instead of at the minimum attribute value

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
added an attribute which is quite important for me: beginAtZero -> to make the scale bein at zero


* **What is the current behavior?** (You can also link to an open issue here)
scale always begins at the minimum value in the provided datasets


* **What is the new behavior (if this is a feature change)?**
developer has the opportunity to make the scale start at 0


* **Other information**:
Tested -> if it is not set, default behavior will be kept the same